### PR TITLE
add :scope provided to clojure and clojurescript

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/philoskim/debux"
   :license {"Eclipse Public License"
             "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.10.238"]
+  :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
+                 [org.clojure/clojurescript "1.10.238" :scope "provided"]
                  [clojure-future-spec "1.9.0-alpha17"]]
   :source-paths ["src"])


### PR DESCRIPTION
This is to avoid dependencies (specially clojurescript) in cases
where they are not used by the project being debugged.