### PR TITLE
Add support for cljs-devtools printing 

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject philoskim/debux "0.5.8"
+(defproject philoskim/debux "0.5.9"
   :description "A trace-based debugging library for Clojure and ClojureScript"
   :url "https://github.com/philoskim/debux"
   :license {"Eclipse Public License"

--- a/src/debux/cs/util.cljc
+++ b/src/debux/cs/util.cljc
@@ -85,9 +85,12 @@
      [result & [js-mode]]
      (let [pprint (str/trim (with-out-str (pp/pprint result)))
            prefix (str (ut/make-bars ut/*indent-level*) "  ")]
-       (.log js/console (->> (str/split pprint #"\n")
-                             (mapv #(str prefix %))
-                             (str/join "\n") ))
+       (.log js/console (if (and (fn? devtools.formatters/installed?)
+                                 (devtools.formatters/installed?))
+                          result
+                          (->> (str/split pprint #"\n")
+                               (mapv #(str prefix %))
+                               (str/join "\n"))))
        (when js-mode
          (.log js/console "%s %c<js>%c %O" prefix (:info @style*) (:normal @style*)
                                            result) ))))


### PR DESCRIPTION
When https://github.com/binaryage/cljs-devtools is depended on by project and the [`:formatter`s](https://github.com/binaryage/cljs-devtools/blob/master/docs/faq.md#what-is-the-formatters-feature) are installed it provides a much more ergonomic developer experience when logging large objects like `app-db`s in the console. This PR adds support for those formatters when they are detected and falls back gracefully to indentation printing when they are not.