### PR TITLE
Fix format of license

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
 (defproject philoskim/debux "0.6.2"
   :description "A trace-based debugging library for Clojure and ClojureScript"
   :url "https://github.com/philoskim/debux"
-  :license {"Eclipse Public License"
-            "http://www.eclipse.org/legal/epl-v10.html"}
+  :license {:name "Eclipse Public License - v 1.0"
+            :url "http://www.eclipse.org/legal/epl-v10.html"
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.10.238"]
                  [clojure-future-spec "1.9.0-alpha17"]


### PR DESCRIPTION
Tiny PR to adjust the format of the map passed in `:license` to make it follow the structure that other tools understand.

Structure taken from https://github.com/technomancy/leiningen/blob/4c601033354640aefa0bdf5c09bdd3646ff5e80c/sample.project.clj#L31-L34