### PR TITLE
fix multiple bindings in for/doseq :let

### DIFF
--- a/src/debux/common/skip.clj
+++ b/src/debux/common/skip.clj
@@ -107,7 +107,9 @@
 (defn- process-for-binding [[binding form]]
   (if (keyword? binding)
     (case binding
-      :let `[~binding (ms/o-skip [(ms/skip ~(first form)) ~(second form)])]
+      :let `[~binding (ms/o-skip ~(->> (partition 2 form)
+                                       (mapcat process-let-binding)
+                                       vec))]
       [binding form])
     `[(ms/skip ~binding) ~form] ))
 


### PR DESCRIPTION
With latest version of debux, compiling this form would result in error `use undeclared var "z"`

```clojure
#d/clogn (doseq [x [1 2 3]
                 :let [y (inc x)
                       z (inc y)]
                 ]
           (when (> z x)
             (println [x y z])))
```