### PR TITLE
fix ns-symbol-for-cljs handling for local vars

### DIFF
--- a/src/debux/common/util.cljc
+++ b/src/debux/common/util.cljc
@@ -157,12 +157,14 @@
    (defn- ns-symbol-for-cljs [sym env]
      (if-let [meta (ana/resolve env sym)]
        ;; normal symbol
-       (let [[ns name] (str/split (str (:name meta)) #"/")]
-         ;; The special symbol `.` must be handled in the following special symbol part.
-         ;; However, the special symbol `.` returns meta {:name / :ns nil}, which may be a bug.
-         (if (nil? ns)
-           sym
-           (symbol ns name) ))
+       (if (= (:op meta) :local)
+         sym
+         (let [[ns name] (str/split (str (:name meta)) #"/")]
+          ;; The special symbol `.` must be handled in the following special symbol part.
+          ;; However, the special symbol `.` returns meta {:name / :ns nil}, which may be a bug.
+          (if (nil? ns)
+            sym
+            (symbol ns name) )))
        ;; special symbols except for `.`
        sym) ))
 


### PR DESCRIPTION
Currently debux would throw NPE when expanding this snippet in CLJS:
```clojure
(defn f1
  [v]
  #d/dbgn (v))
```

A repro of the issue (a complete shadow-cljs project) could be find here: https://github.com/lucywang000/bugs-repro/tree/5a86fcdc19faa6a105a6c99338c3a11c290675dc/repro-debux-npe

The problem is the `ns-symbol-for-cljs` function would return a null symbol name when the symbol is a local variable.