### PR TITLE
Fix reflective access issues

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,7 @@
   :url "https://github.com/philoskim/debux"
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :global-vars {*warn-on-reflection* true}
   :dependencies [[org.clojure/clojure "1.10.0" :scope "provided"]
                  [org.clojure/clojurescript "1.10.238" :scope "provided"]]
   :source-paths ["src"])

--- a/src/debux/common/util.cljc
+++ b/src/debux/common/util.cljc
@@ -241,7 +241,7 @@
         :else
         (recur (z/next loc)) ))))
 
-(defn truncate [s]
+(defn truncate [^String s]
   (if (> (count s) 70)
     (str (.substring s 0 70) " ...")
     s))

--- a/src/debux/common/util.cljc
+++ b/src/debux/common/util.cljc
@@ -241,9 +241,9 @@
         :else
         (recur (z/next loc)) ))))
 
-(defn truncate [^String s]
+(defn truncate [s]
   (if (> (count s) 70)
-    (str (.substring s 0 70) " ...")
+    (str (subs s 0 70) " ...")
     s))
 
 (defn make-bullets


### PR DESCRIPTION
There is currently only one Reflection warning, `Reflection warning, debux/common/util.cljc:220:10 - call to method substring can't be resolved (target class is unknown).`, but I've updated the Lein config as well to prevent this pesky issue in the future.